### PR TITLE
Correct link to Ruby website

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ The gem is available as open source under the terms of the [MIT License].
 
 [arduinolibraries.info]:     https://arduinolibraries.info/
 [MIT License]:               http://opensource.org/licenses/MIT
-[Ruby]:                      http://ruby-lang.org/
+[Ruby]:                      http://www.ruby-lang.org/
 [Bundler]:                   http://bundler.io/
 [http://localhost:3000/]:    http://localhost:3000/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ The gem is available as open source under the terms of the [MIT License].
 
 [arduinolibraries.info]:     https://arduinolibraries.info/
 [MIT License]:               http://opensource.org/licenses/MIT
-[Ruby]:                      http://www.ruby-lang.org/
+[Ruby]:                      https://www.ruby-lang.org/
 [Bundler]:                   http://bundler.io/
 [http://localhost:3000/]:    http://localhost:3000/


### PR DESCRIPTION
There is a long standing issue (https://github.com/ruby/www.ruby-lang.org/issues/2551) where the "www" domain is required for the official Ruby website. This caused the previous link to fail to load.

Compare the results from the previous URL:

http://ruby-lang.org/

to the URL proposed in this PR:

http://www.ruby-lang.org/