### PR TITLE
Record "Any" architecture in index

### DIFF
--- a/bin/build-clean-index.rb
+++ b/bin/build-clean-index.rb
@@ -161,9 +161,9 @@ data[:libraries].each_pair do |key, library|
       architecture = 'Any'
     elsif architecture =~ /^\w+$/
       architecture = architecture.downcase
-      data[:architectures][architecture] ||= []
-      data[:architectures][architecture] << key
     end
+    data[:architectures][architecture] ||= []
+    data[:architectures][architecture] << key
   end
 end
 


### PR DESCRIPTION
The [Arduino library specification](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) allows library authors to specify compatibility with any board architecture by using the `*` value in the `architectures` field of the `library.properties` metadata file.

The "Arduino Library list" code translates this special `*` architecture value to the more human friendly "**Any**" for display to the site's visitors.

The code previously did not record the "**Any**" architecture type in the architectures index, which meant it was not possible to browse the list of libraries which are specified as compatible with any architecture.

I believe this behavior of not recording the "**Any**" architecture was unintentional since it was the behavior [at one time](https://web.archive.org/web/20180224070016/https://www.arduinolibraries.info/), and no mention was made of an intention to change that behavior in the description of the commit which did it: https://github.com/njh/arduino-libraries/commit/bb7db0d9bf7bf048d7c37b5314f1b5407f7a82b6